### PR TITLE
Set `haxe-version` to `latest` in the Windows in Linux workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install & Setup Haxe
         uses: krdlab/setup-haxe@master
         with:
-          haxe-version: 4.3.3
+          haxe-version: latest
 
       - name: Install Libraries
         run: |
@@ -50,7 +50,7 @@ jobs:
       - name: Install & Setup Haxe
         uses: krdlab/setup-haxe@master
         with:
-          haxe-version: 4.3.3
+          haxe-version: latest
 
       - name: Install Libraries
         run: |


### PR DESCRIPTION
So there's no need to manually set the version.