### PR TITLE
Disable preload upon startup

### DIFF
--- a/source/funkin/Preferences.hx
+++ b/source/funkin/Preferences.hx
@@ -37,7 +37,7 @@ class Preferences {
         
         addPref('antialiasing',   'antialiasing',    true);
         addPref('clear-gpu',      'clear gpu cache', false);
-        addPref('preload',        'preload at start', true);
+        addPref('preload',        'preload at start', false);
 
         SaveData.flushData();
         effectPrefs();


### PR DESCRIPTION
Just in case some rubbish computers can't handle *everything* being preloaded into memory all at once